### PR TITLE
Component Validation: PHP 8.4 Support

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -7,23 +7,18 @@ on:
     branches: [ master ]
 
 jobs:
-  ci:
-
+  sonarcloud:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-versions: [ '8.3', '8.4' ]
-
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # To avoid "Shallow clone detected" error in SonarCloud report
 
       #~ PHP Setup
-      - name: Setup PHP ${{ matrix.php-versions }}
+      - name: Setup PHP 8.3 # Minimum version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: '8.3'
 
       #~ Composer Cache
       - name: Get Composer Cache Directory
@@ -38,28 +33,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
-      #~ Composer install
-      - name: Validate composer.json
-        run: composer validate
-
       - name: Install dependencies
         if: steps.composer-cache.outputs.cache-hit != 'true'
         run: make install
 
-      #~ CI part
-      - name: Dependencies
-        run: make php/deps
-
-      - name: Check Code Style
-        run: make php/check
-
       - name: Units Tests
-        run: make php/tests
+        run: make php/tests # To generate the coverage report
 
-      - name: Fix unit tests report path
-        run: |
-          sed -i 's+'$GITHUB_WORKSPACE'+/github/workspace+g' build/reports/phpunit/clover.xml
-          sed -i 's+'$GITHUB_WORKSPACE'+/github/workspace+g' build/reports/phpunit/unit.xml
-
-      - name: PHP Static Analyze
-        run: make php/analyze
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5.2.0
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,24 @@
+<?php
+
+return (new PhpCsFixer\Config())
+    //~ Rules
+    ->setRules(
+        [
+            '@PER-CS2.0' => true,
+        ]
+    )
+
+    //~ Format
+    ->setFormat('txt')
+
+    //~ Cache
+    ->setUsingCache(true)
+    ->setCacheFile(__DIR__ . '/build/.php-cs-fixer.cache')
+
+    //~ Finder
+    ->setFinder((new PhpCsFixer\Finder())->in(
+        [
+            __DIR__ . '/src',
+            __DIR__ . '/tests',
+        ]))
+;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2025-08-015
+[6.0.0]: https://github.com/eureka-framework/component-validation/compare/5.3.0...6.0.0
+### Added
+- Support for PHP 8.4
+### Removed
+- Drop support for PHP 7.4, 8.0, 8.1, and 8.2
+### Changed
+- String validator now throws an exception if values has not the required length, rather than returning default value.
+- Boolean validator now return `null` if the value is not a boolean, rather than return `false`.
+- Type as enforced on validator to return appropriate type (or null if applicable)
+- CI improvements
+
+---
+
 ## [5.3.0] - 2024-02-06
 [5.3.0]: https://github.com/eureka-framework/component-validation/compare/5.2.0...5.3.0
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-.PHONY: validate install update phpcs phpcbf php74compatibility php83compatibility phpstan analyze tests testdox ci clean
+.PHONY: validate install update php/deps php/check php/fix php/min-compatibility php/max-compatibility php/phpstan php/analyze php/tests php/test php/testdox ci clean
 
-PHP_FILES := $(shell find src tests -type f -name '*.php')
+COMPOSER_BIN := composer
+PHP_VERSION_MIN := 8.3
+PHP_VERSION_MAX := 8.4
 define header =
     @if [ -t 1 ]; then printf "\n\e[37m\e[100m  \e[104m $(1) \e[0m\n"; else printf "\n### $(1)\n"; fi
 endef
@@ -8,69 +10,71 @@ endef
 #~ Composer dependency
 validate:
 	$(call header,Composer Validation)
-	@composer validate
+	@${COMPOSER_BIN} validate
 
 install:
 	$(call header,Composer Install)
-	@composer install
+	@${COMPOSER_BIN} install
 
 update:
 	$(call header,Composer Update)
-	@composer update
+	@${COMPOSER_BIN} update
+	@${COMPOSER_BIN} bump --dev-only
 
 composer.lock: install
 
 #~ Vendor binaries dependencies
-vendor/bin/phpcbf:
-vendor/bin/phpcs:
-vendor/bin/phpstan:
-vendor/bin/phpunit:
+vendor/bin/php-cs-fixer: composer.lock
+vendor/bin/phpstan: composer.lock
+vendor/bin/phpunit: composer.lock
 
 #~ Report directories dependencies
 build/reports/phpunit:
 	@mkdir -p build/reports/phpunit
 
-build/reports/phpcs:
-	@mkdir -p build/reports/cs
-
 build/reports/phpstan:
 	@mkdir -p build/reports/phpstan
 
 #~ main commands
-phpcs: vendor/bin/phpcs build/reports/phpcs
+php/deps: composer.json
+	$(call header,Checking Dependencies)
+	@XDEBUG_MODE=off ./vendor/bin/composer-dependency-analyser --config ./ci/composer-dependency-analyser.php # for shadow, unused required dependencies and ext-* missing dependencies
+
+php/check: vendor/bin/php-cs-fixer
 	$(call header,Checking Code Style)
-	@./vendor/bin/phpcs --standard=./ci/phpcs/eureka.xml --cache=./build/cs_eureka.cache -p --report-full --report-checkstyle=./build/reports/cs/eureka.xml src/ tests/
-
-phpcbf: vendor/bin/phpcbf
+	@./vendor/bin/php-cs-fixer check -v --diff
+php/fix: vendor/bin/php-cs-fixer
 	$(call header,Fixing Code Style)
-	@./vendor/bin/phpcbf --standard=./ci/phpcs/eureka.xml src/ tests/
+	@./vendor/bin/php-cs-fixer fix -v
 
-php74compatibility: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Checking PHP 7.4 compatibility)
-	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php74-compatibility.neon --error-format=table
+php/min-compatibility: vendor/bin/phpstan build/reports/phpstan
+	$(call header,Checking PHP ${PHP_VERSION_MIN} compatibility)
+	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/phpmin-compatibility.neon --error-format=table
 
-php83compatibility: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Checking PHP 8.3 compatibility)
-	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/php83-compatibility.neon --error-format=table
+php/max-compatibility: vendor/bin/phpstan build/reports/phpstan #ci
+	$(call header,Checking PHP ${PHP_VERSION_MAX} compatibility)
+	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --configuration=./ci/phpmax-compatibility.neon --error-format=table
 
-analyze: vendor/bin/phpstan build/reports/phpstan
+php/analyze: vendor/bin/phpstan build/reports/phpstan #manual & ci
 	$(call header,Running Static Analyze - Pretty tty format)
 	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --error-format=table
 
-phpstan: vendor/bin/phpstan build/reports/phpstan
-	$(call header,Running Static Analyze)
-	@XDEBUG_MODE=off ./vendor/bin/phpstan analyse --error-format=checkstyle > ./build/reports/phpstan/phpstan.xml
-
-tests: vendor/bin/phpunit build/reports/phpunit $(PHP_FILES)
+php/tests: vendor/bin/phpunit build/reports/phpunit #ci
 	$(call header,Running Unit Tests)
-	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-clover=./build/reports/phpunit/clover.xml --log-junit=./build/reports/phpunit/unit.xml --coverage-php=./build/reports/phpunit/unit.cov --coverage-html=./build/reports/coverage/ --fail-on-warning
+	@XDEBUG_MODE=coverage php ./vendor/bin/phpunit --testsuite=unit --coverage-clover=./build/reports/phpunit/clover.xml --log-junit=./build/reports/phpunit/unit.xml --coverage-php=./build/reports/phpunit/unit.cov --coverage-html=./build/reports/coverage/ --fail-on-warning
 
-testdox: vendor/bin/phpunit $(PHP_FILES)
+php/test: php/tests
+
+php/integration: vendor/bin/phpunit build/reports/phpunit #manual
+	$(call header,Running Integration Tests)
+	@XDEBUG_MODE=coverage php ./vendor/bin/phpunit --testsuite=integration --fail-on-warning
+
+php/testdox: vendor/bin/phpunit #manual
 	$(call header,Running Unit Tests (Pretty format))
-	@XDEBUG_MODE=coverage php -dzend_extension=xdebug.so ./vendor/bin/phpunit --fail-on-warning --testdox
+	@XDEBUG_MODE=coverage php ./vendor/bin/phpunit --testsuite=unit --fail-on-warning --testdox
 
 clean:
-	$(call header,Cleaning previous build)
+	$(call header,Cleaning previous build) #manual
 	@if [ "$(shell ls -A ./build)" ]; then rm -rf ./build/*; fi; echo " done"
 
-ci: clean validate install phpcs tests php74compatibility php83compatibility analyze
+ci: clean validate install php/deps php/check php/tests php/integration php/min-compatibility php/max-compatibility php/analyze

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # component-validation
 
 [![Current version](https://img.shields.io/packagist/v/eureka/component-validation.svg?logo=composer)](https://packagist.org/packages/eureka/component-validation)
-[![Supported PHP version](https://img.shields.io/static/v1?logo=php&label=PHP&message=7.4%20-%208.3&color=777bb4)](https://packagist.org/packages/eureka/component-validation)
+[![Supported PHP version](https://img.shields.io/static/v1?logo=php&label=PHP&message=8.3%20-%208.4&color=777bb4)](https://packagist.org/packages/eureka/component-validation)
 ![CI](https://github.com/eureka-framework/component-validation/workflows/CI/badge.svg)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=eureka-framework_component-validation&metric=alert_status)](https://sonarcloud.io/dashboard?id=eureka-framework_component-validation)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=eureka-framework_component-validation&metric=coverage)](https://sonarcloud.io/dashboard?id=eureka-framework_component-validation)
@@ -94,11 +94,44 @@ make update
 ```
 
 
-## Testing
+## Testing & CI (Continuous Integration)
 
-You can test the component with the following commands:
+You can run tests on your side with following commands:
 ```bash
-make phpcs
-make tests
-make testdox
+make php/tests   # run tests with coverage
+make php/test    # run tests with coverage
+make php/testdox # run tests without coverage reports but with prettified output
 ```
+
+You also can run code style check or code style fixes with following commands:
+```bash
+make php/check   # run checks on check style
+make php/fix     # run check style auto fix
+```
+
+To perform a static analyze of your code (with phpstan, lvl 9 at default), you can use the following command:
+```bash
+make php/analyze # Same as phpstan but with CLI output as table
+```
+
+To ensure you code still compatible with current supported version and futures versions of php, you need to
+run the following commands (both are required for full support):
+```bash
+make php/min-compatibility # run compatibility check on current minimal version of php we support
+make php/max-compatibility # run compatibility check on last version of php we will support in future
+```
+
+And the last "helper" commands, you can run before commit and push is:
+```bash
+make ci
+```
+This command clean the previous reports, install component if needed and run tests (with coverage report),
+check the code style and check the php compatibility check, as it would be done in our CI.
+
+## Contributing
+
+See the [CONTRIBUTING](CONTRIBUTING.md) file.
+
+## License
+
+This project is currently under The MIT License (MIT). See [LICENCE](LICENSE) file for more information.

--- a/ci/composer-dependency-analyser.php
+++ b/ci/composer-dependency-analyser.php
@@ -1,0 +1,11 @@
+<?php
+
+use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
+use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
+
+$config = new Configuration();
+
+return $config
+    ->addPathToScan(__DIR__ . '/../src', isDev: false)
+    ->addPathToScan(__DIR__ . '/../tests', isDev: true)
+;

--- a/ci/php74-compatibility.neon
+++ b/ci/php74-compatibility.neon
@@ -1,9 +1,0 @@
-parameters:
-  phpVersion: 70400 # PHP 7.4
-  level: 0
-  paths:
-    - ./../src
-    - ./../tests
-
-  bootstrapFiles:
-    - ./../vendor/autoload.php

--- a/ci/phpcs/eureka.xml
+++ b/ci/phpcs/eureka.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0"?>
-<ruleset name="eureka">
-    <description>The coding standard for Eureka.</description>
-
-    <arg value="nps"/>
-
-    <rule ref="PSR12"/>
-</ruleset>

--- a/ci/phpmax-compatibility.neon
+++ b/ci/phpmax-compatibility.neon
@@ -1,0 +1,14 @@
+includes:
+  - ./../vendor/phpstan/phpstan-phpunit/extension.neon
+  - ./../vendor/phpstan/phpstan-phpunit/rules.neon
+
+parameters:
+  phpVersion: 80400
+  level: 0
+
+  paths:
+    - ./../src
+    - ./../tests
+
+  bootstrapFiles:
+    - ./../vendor/autoload.php

--- a/ci/phpmin-compatibility.neon
+++ b/ci/phpmin-compatibility.neon
@@ -1,6 +1,11 @@
+includes:
+  - ./../vendor/phpstan/phpstan-phpunit/extension.neon
+  - ./../vendor/phpstan/phpstan-phpunit/rules.neon
+
 parameters:
   phpVersion: 80300
   level: 0
+
   paths:
     - ./../src
     - ./../tests

--- a/composer.json
+++ b/composer.json
@@ -23,22 +23,25 @@
       "Eureka\\Component\\Validation\\Tests\\": "./tests"
     }
   },
-
-  "require": {
-    "php": "7.4.*||8.0.*||8.1.*||8.2.*||8.3.*"
-  },
-
-  "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
-    "phpstan/phpstan": "^1.10",
-    "phpunit/phpcov": "^8.2",
-    "phpunit/phpunit": "^9.6",
-    "squizlabs/php_codesniffer": "^3.7",
-    "symfony/cache": "^5.4||^6.3"
-  },
   "config": {
     "allow-plugins": {
       "dealerdirect/phpcodesniffer-composer-installer": true
     }
+  },
+
+  "require": {
+    "php": "8.3.*||8.4.*",
+    "ext-filter": "*",
+    "ext-mbstring": "*"
+  },
+
+  "require-dev": {
+    "friendsofphp/php-cs-fixer": "^3.86.0",
+    "phpstan/phpstan": "^2.1.22",
+    "phpstan/phpstan-phpunit": "^2.0.7",
+    "phpstan/phpstan-strict-rules": "^2.0.6",
+    "phpunit/phpcov": "^11.0.1",
+    "phpunit/phpunit": "^12.3.4",
+    "shipmonk/composer-dependency-analyser": "^1.8.3"
   }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,10 @@
+includes:
+  - ./vendor/phpstan/phpstan-phpunit/extension.neon
+  - ./vendor/phpstan/phpstan-phpunit/rules.neon
+  - ./vendor/phpstan/phpstan-strict-rules/rules.neon
+
 parameters:
-  phpVersion: 70400 # PHP 7.4 - Current minimal version supported
+  phpVersion: 80300
   level: max
   paths:
     - ./src
@@ -7,6 +12,8 @@ parameters:
 
   bootstrapFiles:
     - ./vendor/autoload.php
+
+  treatPhpDocTypesAsCertain: false
 
   ignoreErrors:
     - '#Call to an undefined method Eureka\\Component\\Validation\\Entity\\GenericEntity::.+\(\).#'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,34 +1,36 @@
 <?xml version="1.0"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.2/phpunit.xsd"
         backupGlobals="true"
-        backupStaticAttributes="false"
         colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
-        forceCoversAnnotation="false"
-        processIsolation="false"
-        stopOnError="false"
-        stopOnFailure="false"
-        stopOnIncomplete="false"
-        stopOnSkipped="false"
-        stopOnRisky="false"
-        timeoutForSmallTests="1"
-        timeoutForMediumTests="10"
-        timeoutForLargeTests="60"
-        verbose="false">
+        failOnEmptyTestSuite="false"
+        failOnIncomplete="true"
+        failOnRisky="true"
+        failOnWarning="true"
+        displayDetailsOnTestsThatTriggerDeprecations="true"
+        displayDetailsOnPhpunitDeprecations="true"
+        displayDetailsOnTestsThatTriggerErrors="true"
+        displayDetailsOnTestsThatTriggerNotices="true"
+        displayDetailsOnTestsThatTriggerWarnings="true"
+        cacheDirectory="build/.phpunit.cache">
 
-  <coverage>
+  <php>
+    <ini name="error_reporting" value="E_ALL"/>
+  </php>
+
+  <source>
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+  </source>
 
   <testsuites>
-    <testsuite name="Test suite">
-      <directory>./tests</directory>
+    <testsuite name="unit">
+      <directory>./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="integration">
+      <directory>./tests/Integration</directory>
     </testsuite>
   </testsuites>
 

--- a/src/Entity/GenericEntity.php
+++ b/src/Entity/GenericEntity.php
@@ -49,7 +49,7 @@ class GenericEntity
             $this->validatorConfig[self::toPascalCase($name)] = $config;
         }
 
-        if (!empty($data)) {
+        if ($data !== []) {
             $this->setFromArray($data);
         }
     }
@@ -59,7 +59,7 @@ class GenericEntity
      */
     public function isValid(): bool
     {
-        return empty($this->errors);
+        return $this->errors === [];
     }
 
     /**
@@ -102,36 +102,23 @@ class GenericEntity
     /**
      * Magic method to have getters & setters for generic entity.
      *
-     * @param  string $name
      * @param  array<int, int|float|bool|string|null> $arguments
-     * @return $this|int|float|bool|string|null
      * @throws \LogicException
      */
-    public function __call(string $name, array $arguments)
+    public function __call(string $name, array $arguments): self|int|float|bool|string|null
     {
-        $prefixOriginal  = substr($name, 0, 3);
-        $prefixAlternate = substr($name, 0, 2);
+        $prefix3Chars = \substr($name, 0, 3);
+        $prefix2Chars = \substr($name, 0, 2);
 
-        switch (true) {
-            case $prefixAlternate === 'in':
-            case $prefixAlternate === 'is':
-            case $prefixOriginal === 'has':
-                return $this->get($name);
-            case $prefixOriginal === 'get':
-                return $this->get(substr($name, 3));
-            case $prefixOriginal === 'set':
-                return $this->set(substr($name, 3), ...$arguments);
-            default:
-                throw new \LogicException('Invalid method name.');
-        }
+        return match (true) {
+            $prefix3Chars === 'has', $prefix2Chars === 'in', $prefix2Chars === 'is' => $this->get($name),
+            $prefix3Chars === 'get' => $this->get(\substr($name, 3)),
+            $prefix3Chars === 'set' => $this->set(\substr($name, 3), ...$arguments),
+            default => throw new \LogicException('Invalid method name.'),
+        };
     }
 
-    /**
-     * @param  string $name
-     * @param  int|float|bool|string|null $value
-     * @return $this
-     */
-    protected function set(string $name, $value): self
+    protected function set(string $name, int|float|bool|string|null $value): self
     {
         $name = self::toPascalCase($name);
 
@@ -150,11 +137,7 @@ class GenericEntity
         return $this;
     }
 
-    /**
-     * @param  string $name
-     * @return int|float|bool|string|null
-     */
-    protected function get(string $name)
+    protected function get(string $name): int|float|bool|string|null
     {
         $name = self::toPascalCase($name);
 
@@ -171,6 +154,6 @@ class GenericEntity
      */
     protected static function toPascalCase(string $name): string
     {
-        return strtr(ucwords(strtr($name, ['_' => ' ', '.' => '_ ', '\\' => '_ '])), [' ' => '']);
+        return \strtr(\ucwords(\strtr($name, ['_' => ' ', '.' => '_ ', '\\' => '_ '])), [' ' => '']);
     }
 }

--- a/src/Exception/ValidationException.php
+++ b/src/Exception/ValidationException.php
@@ -16,6 +16,4 @@ namespace Eureka\Component\Validation\Exception;
  *
  * @author Romain Cottard
  */
-class ValidationException extends \RuntimeException
-{
-}
+class ValidationException extends \RuntimeException {}

--- a/src/Validator/AbstractValidator.php
+++ b/src/Validator/AbstractValidator.php
@@ -11,19 +11,17 @@ declare(strict_types=1);
 
 namespace Eureka\Component\Validation\Validator;
 
-use Eureka\Component\Validation\Exception\ValidationException;
+use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class BooleanValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class AbstractValidator
 {
     /**
-     * @param  array<string,string|float|int|bool|null> $options
+     * @param  OptionsType $options
      * @param  int|null $flags
-     * @return array<string,int|null|array<string,string|float|int|bool|null>>
+     * @return array{options: OptionsType, flags: int|null}
      */
     protected function getOptions(array $options = [], ?int $flags = FILTER_DEFAULT): array
     {

--- a/src/Validator/BooleanValidator.php
+++ b/src/Validator/BooleanValidator.php
@@ -15,28 +15,22 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class BooleanValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class BooleanValidator extends AbstractValidator implements ValidatorInterface
 {
     /**
-     * @param mixed $value
-     * @param array<string,string|null|int|float|bool> $options
-     * @param int|null $flags
-     * @return bool|null
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null): ?bool
+    public function validate(mixed $value, array $options = [], ?int $flags = null): ?bool
     {
         if ($flags === null) {
-            $flags = !array_key_exists('default', $options) ? FILTER_NULL_ON_FAILURE : FILTER_DEFAULT;
+            $flags = !\array_key_exists('default', $options) ? \FILTER_NULL_ON_FAILURE : \FILTER_DEFAULT;
         }
 
-        /** @var bool|null $filteredValue */
-        $filteredValue = filter_var($value, FILTER_VALIDATE_BOOLEAN, $this->getOptions($options, $flags));
+        $filteredValue = \filter_var($value, \FILTER_VALIDATE_BOOLEAN, $this->getOptions($options, $flags));
 
-        if (null === $filteredValue) {
+        if (!\is_bool($filteredValue) && $filteredValue !== null) {
             throw new ValidationException('Given value is not a valid boolean!');
         }
 

--- a/src/Validator/DateTimeTrait.php
+++ b/src/Validator/DateTimeTrait.php
@@ -12,14 +12,15 @@ declare(strict_types=1);
 namespace Eureka\Component\Validation\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
+use Eureka\Component\Validation\ValidatorInterface;
 
+/**
+ * @phpstan-import-type OptionsType from ValidatorInterface
+ */
 trait DateTimeTrait
 {
     /**
-     * @param string $value
-     * @param  array<string,string|float|int|bool|null> $options
-     * @param string $defaultFormat
-     * @return string|null
+     * @param OptionsType $options
      */
     protected function getDateOrDefault(string $value, array $options, string $defaultFormat): ?string
     {
@@ -36,7 +37,7 @@ trait DateTimeTrait
         if (! $date instanceof \DateTimeImmutable) {
             if (!array_key_exists('default', $options)) {
                 throw new ValidationException(
-                    'Given value is not a valid date or time according to following format: "' . $options['format'] . '"!'
+                    'Given value is not a valid date or time according to following format: "' . $options['format'] . '"!',
                 );
             }
 

--- a/src/Validator/DateTimeValidator.php
+++ b/src/Validator/DateTimeValidator.php
@@ -15,22 +15,21 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class DateTimeValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class DateTimeValidator extends AbstractValidator implements ValidatorInterface
 {
     use DateTimeTrait;
 
     /**
-     * @param  string $value
-     * @param  array<string,string> $options
-     * @param  int|null $flags Not used here.
-     * @return string|null Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null): ?string
+    public function validate(mixed $value, array $options = [], ?int $flags = null): ?string
     {
+        if (!\is_string($value)) {
+            throw new ValidationException('Value must be a string');
+        }
+
         return $this->getDateOrDefault($value, $options, 'Y-m-d H:i:s');
     }
 }

--- a/src/Validator/DateValidator.php
+++ b/src/Validator/DateValidator.php
@@ -15,22 +15,21 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class DateValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class DateValidator extends AbstractValidator implements ValidatorInterface
 {
     use DateTimeTrait;
 
     /**
-     * @param  string $value
-     * @param  array<string,string> $options
-     * @param  int|null $flags Not used here.
-     * @return string|null Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null): ?string
+    public function validate(mixed $value, array $options = [], ?int $flags = null): ?string
     {
+        if (!\is_string($value)) {
+            throw new ValidationException('Value must be a string');
+        }
+
         return $this->getDateOrDefault($value, $options, 'Y-m-d');
     }
 }

--- a/src/Validator/DomainValidator.php
+++ b/src/Validator/DomainValidator.php
@@ -15,24 +15,23 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class DomainValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class DomainValidator extends AbstractValidator implements ValidatorInterface
 {
     /**
-     * @param  mixed $value
-     * @param  array<string,string|float|int|bool|null> $options
-     * @param  int|null $flags Not used here.
-     * @return mixed Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = FILTER_DEFAULT)
+    public function validate(mixed $value, array $options = [], ?int $flags = FILTER_DEFAULT): ?string
     {
-        $filteredValue = filter_var($value, FILTER_VALIDATE_DOMAIN, $this->getOptions($options, $flags));
+        $filteredValue = \filter_var($value, FILTER_VALIDATE_DOMAIN, $this->getOptions($options, $flags));
 
-        if (false === $filteredValue) {
+        if ($filteredValue === false) {
             throw new ValidationException('Given value is not a valid domain!');
+        }
+
+        if ($filteredValue !== null && !\is_string($filteredValue)) {
+            throw new ValidationException('Optional value must be a string or null!');
         }
 
         return $filteredValue;

--- a/src/Validator/EmailValidator.php
+++ b/src/Validator/EmailValidator.php
@@ -15,24 +15,23 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class EmailValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class EmailValidator extends AbstractValidator implements ValidatorInterface
 {
     /**
-     * @param  mixed $value
-     * @param  array<string,string|float|int|bool|null> $options
-     * @param  int|null $flags Not used here.
-     * @return mixed Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = FILTER_DEFAULT)
+    public function validate(mixed $value, array $options = [], ?int $flags = FILTER_DEFAULT): ?string
     {
-        $filteredValue = filter_var($value, FILTER_VALIDATE_EMAIL, $this->getOptions($options, $flags));
+        $filteredValue = \filter_var($value, FILTER_VALIDATE_EMAIL, $this->getOptions($options, $flags));
 
-        if (false === $filteredValue) {
+        if ($filteredValue === false) {
             throw new ValidationException('Given value is not a valid email!');
+        }
+
+        if ($filteredValue !== null && !\is_string($filteredValue)) {
+            throw new ValidationException('Optional value must be a string or null!');
         }
 
         return $filteredValue;

--- a/src/Validator/FloatValidator.php
+++ b/src/Validator/FloatValidator.php
@@ -15,24 +15,23 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class FloatValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class FloatValidator extends AbstractValidator implements ValidatorInterface
 {
     /**
-     * @param  mixed $value
-     * @param  array<string,string|float|int|bool|null> $options
-     * @param  int|null $flags Not used here.
-     * @return mixed Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null)
+    public function validate(mixed $value, array $options = [], ?int $flags = null): ?float
     {
-        $filteredValue = filter_var($value, FILTER_VALIDATE_FLOAT, $this->getOptions($options, $flags));
+        $filteredValue = \filter_var($value, FILTER_VALIDATE_FLOAT, $this->getOptions($options, $flags));
 
-        if (false === $filteredValue) {
+        if ($filteredValue === false) {
             throw new ValidationException('Given value is not a valid float!');
+        }
+
+        if ($filteredValue !== null && !\is_float($filteredValue)) {
+            throw new ValidationException('Optional value must be a float or null!');
         }
 
         return $filteredValue;

--- a/src/Validator/IntegerValidator.php
+++ b/src/Validator/IntegerValidator.php
@@ -15,35 +15,34 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class IntegerValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class IntegerValidator extends AbstractValidator implements ValidatorInterface
 {
-    const TINYINT_SIGNED     = ['min_range' => -128, 'max_range' => 127];
-    const TINYINT_UNSIGNED   = ['min_range' => 0, 'max_range' => 255];
-    const SMALLINT_SIGNED    = ['min_range' => -32768, 'max_range' => 32767];
-    const SMALLINT_UNSIGNED  = ['min_range' => 0, 'max_range' => 65535];
-    const MEDIUMINT_SIGNED   = ['min_range' => -8388608, 'max_range' => 8388607];
-    const MEDIUMINT_UNSIGNED = ['min_range' => 0, 'max_range' => 16777215];
-    const INT_SIGNED         = ['min_range' => -2147483648, 'max_range' => 2147483647];
-    const INT_UNSIGNED       = ['min_range' => 0, 'max_range' => 4294967295];
-    const BIGINT_SIGNED      = ['min_range' => -9223372036854775808, 'max_range' => 9223372036854775807];
-    const BIGINT_UNSIGNED    = ['min_range' => 0, 'max_range' => 18446744073709551615];
+    public const array TINYINT_SIGNED     = ['min_range' => -128, 'max_range' => 127];
+    public const array TINYINT_UNSIGNED   = ['min_range' => 0, 'max_range' => 255];
+    public const array SMALLINT_SIGNED    = ['min_range' => -32_768, 'max_range' => 32_767];
+    public const array SMALLINT_UNSIGNED  = ['min_range' => 0, 'max_range' => 65_535];
+    public const array MEDIUMINT_SIGNED   = ['min_range' => -8_388_608, 'max_range' => 8_388_607];
+    public const array MEDIUMINT_UNSIGNED = ['min_range' => 0, 'max_range' => 16_777_215];
+    public const array INT_SIGNED         = ['min_range' => -2_147_483_648, 'max_range' => 2_147_483_647];
+    public const array INT_UNSIGNED       = ['min_range' => 0, 'max_range' => 4_294_967_295];
+    public const array BIGINT_SIGNED      = ['min_range' => -9_223_372_036_854_775_808, 'max_range' => 9_223_372_036_854_775_807];
+    public const array BIGINT_UNSIGNED    = ['min_range' => 0, 'max_range' => PHP_INT_MAX]; // PHP_INT_MAX is platform dependent, but usually it is 9_223_372_036_854_775_807 on 64-bit systems
 
     /**
-     * @param  mixed $value
-     * @param  array<string,string|float|int|bool|null> $options
-     * @param  int|null $flags Not used here.
-     * @return mixed Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null)
+    public function validate(mixed $value, array $options = [], ?int $flags = null): ?int
     {
-        $filteredValue = filter_var($value, FILTER_VALIDATE_INT, $this->getOptions($options, $flags));
+        $filteredValue = \filter_var($value, FILTER_VALIDATE_INT, $this->getOptions($options, $flags));
 
-        if (false === $filteredValue) {
+        if ($filteredValue === false) {
             throw new ValidationException('Given value is not a valid integer!');
+        }
+
+        if ($filteredValue !== null && !\is_int($filteredValue)) {
+            throw new ValidationException('Optional value must be a float or null!');
         }
 
         return $filteredValue;

--- a/src/Validator/IpValidator.php
+++ b/src/Validator/IpValidator.php
@@ -15,26 +15,25 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class IpValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class IpValidator extends AbstractValidator implements ValidatorInterface
 {
     /**
-     * @param  mixed $value
-     * @param  array<string,string|float|int|bool|null> $options
-     * @param  int|null $flags Not used here.
-     * @return mixed Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null)
+    public function validate(mixed $value, array $options = [], ?int $flags = null): ?string
     {
         $flags = ($flags === null ? FILTER_FLAG_IPV4 : $flags);
 
-        $filteredValue = filter_var($value, FILTER_VALIDATE_IP, $this->getOptions($options, $flags));
+        $filteredValue = \filter_var($value, FILTER_VALIDATE_IP, $this->getOptions($options, $flags));
 
-        if (false === $filteredValue) {
+        if ($filteredValue === false) {
             throw new ValidationException('Given value is not a valid IP!');
+        }
+
+        if ($filteredValue !== null && !\is_string($filteredValue)) {
+            throw new ValidationException('Optional value must be a string or null!');
         }
 
         return $filteredValue;

--- a/src/Validator/NullValidator.php
+++ b/src/Validator/NullValidator.php
@@ -15,19 +15,14 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class NullValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class NullValidator extends AbstractValidator implements ValidatorInterface
 {
     /**
-     * @param  mixed $value
-     * @param  array<string,string|float|int|bool|null> $options
-     * @param  int|null $flags Not used here.
-     * @return mixed Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null)
+    public function validate(mixed $value, array $options = [], ?int $flags = null): null
     {
         if ($value !== null) {
             throw new ValidationException('Given value is not null!');

--- a/src/Validator/RegexpValidator.php
+++ b/src/Validator/RegexpValidator.php
@@ -15,24 +15,23 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class RegexpValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class RegexpValidator extends AbstractValidator implements ValidatorInterface
 {
     /**
-     * @param  mixed $value
-     * @param  array<string,string|float|int|bool|null> $options
-     * @param  int|null $flags Not used here.
-     * @return mixed Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null)
+    public function validate(mixed $value, array $options = [], ?int $flags = null): ?string
     {
-        $filteredValue = filter_var($value, FILTER_VALIDATE_REGEXP, $this->getOptions($options, FILTER_DEFAULT));
+        $filteredValue = \filter_var($value, FILTER_VALIDATE_REGEXP, $this->getOptions($options));
 
-        if (false === $filteredValue) {
+        if ($filteredValue === false) {
             throw new ValidationException('Given value is not a valid value according to the given regexp!');
+        }
+
+        if ($filteredValue !== null && !\is_string($filteredValue)) {
+            throw new ValidationException('Optional value must be a string or null!');
         }
 
         return $filteredValue;

--- a/src/Validator/StringValidator.php
+++ b/src/Validator/StringValidator.php
@@ -15,25 +15,21 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class StringValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class StringValidator extends AbstractValidator implements ValidatorInterface
 {
     /**
-     * @param  mixed $value
-     * @param  array<string,string|float|int|bool|null> $options
-     * @param  int|null $flags Not used here.
-     * @return mixed Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null)
+    public function validate(mixed $value, array $options = [], ?int $flags = null): ?string
     {
-        $default = array_key_exists('default', $options) ? $options['default'] : false;
+        $default    = \array_key_exists('default', $options) ? $options['default'] : false;
+        $hasDefault = $default === null || \is_string($default);
 
         //~ Validate type
-        if (false === is_string($value)) {
-            if ($default === false) {
+        if (!\is_string($value)) {
+            if (!$hasDefault) {
                 throw new ValidationException('Given value is not a string!');
             }
 
@@ -41,21 +37,13 @@ class StringValidator extends AbstractValidator implements ValidatorInterface
         }
 
         //~ Validate min length
-        if (isset($options['min_length']) && mb_strlen($value) < (int) $options['min_length']) {
-            if ($default === false) {
-                throw new ValidationException('String must have at least ' . $options['min_length'] . ' characters!');
-            }
-
-            return $default;
+        if (isset($options['min_length']) && \mb_strlen($value) < (int) $options['min_length']) {
+            throw new ValidationException('String must have at least ' . $options['min_length'] . ' characters!');
         }
 
         //~ Validate max length
         if (isset($options['max_length']) && mb_strlen($value) > (int) $options['max_length']) {
-            if ($default === false) {
-                throw new ValidationException('String must have maximum ' . $options['max_length'] . ' characters!');
-            }
-
-            return $default;
+            throw new ValidationException('String must have maximum ' . $options['max_length'] . ' characters!');
         }
 
         return $value;

--- a/src/Validator/TimeValidator.php
+++ b/src/Validator/TimeValidator.php
@@ -15,22 +15,21 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class TimeValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class TimeValidator extends AbstractValidator implements ValidatorInterface
 {
     use DateTimeTrait;
 
     /**
-     * @param  string $value
-     * @param  array<string,string> $options
-     * @param  int|null $flags Not used here.
-     * @return string|null Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null): ?string
+    public function validate(mixed $value, array $options = [], ?int $flags = null): ?string
     {
+        if (!\is_string($value)) {
+            throw new ValidationException('Value must be a string');
+        }
+
         return $this->getDateOrDefault($value, $options, 'H:i:s');
     }
 }

--- a/src/Validator/TimestampValidator.php
+++ b/src/Validator/TimestampValidator.php
@@ -15,27 +15,26 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class TimestampValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class TimestampValidator extends AbstractValidator implements ValidatorInterface
 {
     /**
-     * @param  mixed $value
-     * @param  array<string,string|float|int|bool|null> $options
-     * @param  int|null $flags Not used here.
-     * @return mixed Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null)
+    public function validate(mixed $value, array $options = [], ?int $flags = null): ?int
     {
         $options['min_range'] = 0;
         $options['max_range'] = 2147483647;
 
-        $filteredValue = filter_var($value, FILTER_VALIDATE_INT, $this->getOptions($options, $flags));
+        $filteredValue = \filter_var($value, \FILTER_VALIDATE_INT, $this->getOptions($options, $flags));
 
-        if (false === $filteredValue) {
+        if ($filteredValue === false) {
             throw new ValidationException('Given value is not a valid integer!');
+        }
+
+        if ($filteredValue !== null && !\is_int($filteredValue)) {
+            throw new ValidationException('Optional value must be a string or null!');
         }
 
         return $filteredValue;

--- a/src/Validator/UrlValidator.php
+++ b/src/Validator/UrlValidator.php
@@ -15,24 +15,23 @@ use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\ValidatorInterface;
 
 /**
- * Class UrlValidator
- *
- * @author Romain Cottard
+ * @phpstan-import-type OptionsType from ValidatorInterface
  */
 class UrlValidator extends AbstractValidator implements ValidatorInterface
 {
     /**
-     * @param  mixed $value
-     * @param  array<string,string|float|int|bool|null> $options
-     * @param  int|null $flags Not used here.
-     * @return mixed Return value
+     * @param OptionsType $options
      */
-    public function validate($value, array $options = [], ?int $flags = null)
+    public function validate(mixed $value, array $options = [], ?int $flags = null): ?string
     {
-        $filteredValue = filter_var($value, FILTER_VALIDATE_URL, $this->getOptions($options, FILTER_DEFAULT));
+        $filteredValue = \filter_var($value, FILTER_VALIDATE_URL, $this->getOptions($options));
 
-        if (false === $filteredValue) {
+        if ($filteredValue === false) {
             throw new ValidationException('Given value is not a valid url!');
+        }
+
+        if ($filteredValue !== null && !\is_string($filteredValue)) {
+            throw new ValidationException('Optional value must be a string or null!');
         }
 
         return $filteredValue;

--- a/src/ValidatorEntityFactoryInterface.php
+++ b/src/ValidatorEntityFactoryInterface.php
@@ -11,16 +11,11 @@ declare(strict_types=1);
 
 namespace Eureka\Component\Validation;
 
-/**
- * Class ValidatorEntityFactoryInterface
- *
- * @author Romain Cottard
- */
 interface ValidatorEntityFactoryInterface
 {
     /**
-     * @param array<string,mixed> $config
-     * @param array<string,mixed> $data
+     * @param array<string, array<string, array<string, int|float|bool|string|null>|int|float|bool|string|null>> $config
+     * @param array<string, int|float|bool|string|null> $data
      * @return Entity\GenericEntity
      */
     public function createGeneric(array $config, array $data = []): Entity\GenericEntity;

--- a/src/ValidatorFactory.php
+++ b/src/ValidatorFactory.php
@@ -11,60 +11,30 @@ declare(strict_types=1);
 
 namespace Eureka\Component\Validation;
 
-use Eureka\Component\Validation\Validator;
-
-/**
- * Validator factory
- *
- * @author Romain Cottard
- */
 class ValidatorFactory implements ValidatorFactoryInterface
 {
     /** @var ValidatorInterface[] $validators
      */
     protected static array $validators = [];
 
-    /**
-     * @param  string $type
-     * @return ValidatorInterface
-     * @throws \LogicException
-     */
     public function getValidator(string $type): ValidatorInterface
     {
-        switch ($type) {
-            case 'boolean':
-                return $this->getBooleanValidator();
-            case 'datetime':
-                return $this->getDateTimeValidator();
-            case 'date':
-                return $this->getDateValidator();
-            case 'time':
-                return $this->getTimeValidator();
-            case 'timestamp':
-                return $this->getTimestampValidator();
-            case 'email':
-                return $this->getEmailValidator();
-            case 'float':
-            case 'double':
-            case 'decimal':
-                return $this->getFloatValidator();
-            case 'integer':
-                return $this->getIntegerValidator();
-            case 'null':
-            case '~':
-            case '':
-                return $this->getNullValidator();
-            case 'ip':
-                return $this->getIpValidator();
-            case 'regexp':
-                return $this->getRegexpValidator();
-            case 'url':
-                return $this->getUrlValidator();
-            case 'string':
-                return $this->getStringValidator();
-            default:
-                throw new \LogicException('Invalid validator type (type: ' . $type . ')');
-        }
+        return match ($type) {
+            'boolean'       => $this->getBooleanValidator(),
+            'datetime'      => $this->getDateTimeValidator(),
+            'date'          => $this->getDateValidator(),
+            'time'          => $this->getTimeValidator(),
+            'timestamp'     => $this->getTimestampValidator(),
+            'email'         => $this->getEmailValidator(),
+            'integer'       => $this->getIntegerValidator(),
+            'null', '~', '' => $this->getNullValidator(),
+            'ip'            => $this->getIpValidator(),
+            'regexp'        => $this->getRegexpValidator(),
+            'url'           => $this->getUrlValidator(),
+            'string'        => $this->getStringValidator(),
+            'float', 'double', 'decimal' => $this->getFloatValidator(),
+            default => throw new \LogicException('Invalid validator type (type: ' . $type . ')'),
+        };
     }
 
     public function getBooleanValidator(): ValidatorInterface

--- a/src/ValidatorFactoryInterface.php
+++ b/src/ValidatorFactoryInterface.php
@@ -11,16 +11,7 @@ declare(strict_types=1);
 
 namespace Eureka\Component\Validation;
 
-/**
- * Interface Validator Factory for Validator Factory classes
- *
- * @author Romain Cottard
- */
 interface ValidatorFactoryInterface
 {
-    /**
-     * @param  string $type
-     * @return ValidatorInterface
-     */
     public function getValidator(string $type): ValidatorInterface;
 }

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -12,18 +12,15 @@ declare(strict_types=1);
 namespace Eureka\Component\Validation;
 
 /**
- * Interface Validator for Validator classes
- *
- * @author Romain Cottard
+ * @phpstan-type OptionsType array<string,string|null|int|float|bool>
  */
 interface ValidatorInterface
 {
     /**
      * @param mixed $value Value to validate
-     * @param array<string,string|null|int|float|bool> $options
+     * @param OptionsType $options
      * @param int|null   $flags Validation flag. If null, use default flag or validator default flag.
-     * @return mixed Return value
      * @throws \RuntimeException
      */
-    public function validate($value, array $options = [], int $flags = null);
+    public function validate(mixed $value, array $options = [], ?int $flags = null): string|float|int|bool|null;
 }

--- a/tests/Unit/Entity/GenericEntityTest.php
+++ b/tests/Unit/Entity/GenericEntityTest.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Entity;
+namespace Eureka\Component\Validation\Tests\Unit\Entity;
 
 use Eureka\Component\Validation\Entity\GenericEntity;
 use Eureka\Component\Validation\Entity\ValidatorEntityFactory;
@@ -43,13 +43,13 @@ class GenericEntityTest extends TestCase
 
         $entity = new GenericEntity(new ValidatorFactory(), $config, $data);
 
-        $this->assertTrue($entity->isValid());
-        $this->assertTrue($entity->isEnabled());
-        $this->assertSame(1, $entity->getUserId());
+        self::assertTrue($entity->isValid());
+        self::assertTrue($entity->isEnabled());
+        self::assertSame(1, $entity->getUserId());
 
         $entity->setUserId(2);
-        $this->assertSame(2, $entity->getUserId());
-        $this->assertNull($entity->getAny());
+        self::assertSame(2, $entity->getUserId());
+        self::assertNull($entity->getAny());
     }
 
     public function testIHaveAnExceptionWhenITryToGetValueWithAnInvalidMethodName(): void
@@ -79,7 +79,7 @@ class GenericEntityTest extends TestCase
 
         $entity = new GenericEntity(new ValidatorFactory(), $config, $data);
 
-        $this->assertFalse($entity->isValid());
-        $this->assertCount(1, $entity->getErrors());
+        self::assertFalse($entity->isValid());
+        self::assertCount(1, $entity->getErrors());
     }
 }

--- a/tests/Unit/FactoryValidatorTest.php
+++ b/tests/Unit/FactoryValidatorTest.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests;
+namespace Eureka\Component\Validation\Tests\Unit;
 
 use Eureka\Component\Validation\Validator\BooleanValidator;
 use Eureka\Component\Validation\Validator\DateTimeValidator;
@@ -26,6 +26,7 @@ use Eureka\Component\Validation\Validator\TimeValidator;
 use Eureka\Component\Validation\Validator\UrlValidator;
 use Eureka\Component\Validation\ValidatorFactory;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -50,13 +51,12 @@ class FactoryValidatorTest extends TestCase
      * @param string $type
      * @param class-string<ValidatorInterface> $expectedClass
      * @return void
-     *
-     * @dataProvider dataProviderFactory
      */
+    #[DataProvider('dataProviderFactory')]
     public function testICanGetValidatorWithFactory(string $type, string $expectedClass): void
     {
         $validator = $this->factory->getValidator($type);
-        $this->assertInstanceOf($expectedClass, $validator);
+        self::assertInstanceOf($expectedClass, $validator);
     }
 
     /**
@@ -71,7 +71,7 @@ class FactoryValidatorTest extends TestCase
     /**
      * @return string[][]
      */
-    public function dataProviderFactory(): array
+    public static function dataProviderFactory(): array
     {
         return [
             ['boolean', BooleanValidator::class],

--- a/tests/Unit/Validator/BooleanValidatorTest.php
+++ b/tests/Unit/Validator/BooleanValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\BooleanValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,68 +32,58 @@ class BooleanValidatorTest extends TestCase
         return new BooleanValidator();
     }
 
-    /**
-     * @param  mixed $value
-     * @param  bool $excepted
-     * @return void
-     * @dataProvider validTrueValuesProvider
-     */
-    public function testWithValidTrueValues($value, bool $excepted): void
+    #[DataProvider('validTrueValuesProvider')]
+    public function testWithValidTrueValues(mixed $value, bool $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
-    /**
-     * @param  mixed $value
-     * @param  bool $excepted
-     * @return void
-     * @dataProvider validFalseValuesProvider
-     */
-    public function testWithValidFalseValues($value, bool $excepted): void
+    #[DataProvider('validFalseValuesProvider')]
+    public function testWithValidFalseValues(mixed $value, bool $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
-    /**
-     * @param  mixed $value
-     * @param  bool $excepted
-     * @return void
-     * @dataProvider invalidBooleanValuesProvider
-     */
-    public function testWithInvalidBooleanValues($value, bool $excepted): void
+    #[DataProvider('invalidBooleanValuesProvider')]
+    public function testWithInvalidBooleanValuesAnd(mixed $value, bool $excepted): void
+    {
+        self::assertNull($this->getValidator()->validate($value));
+    }
+
+    #[DataProvider('invalidBooleanValuesProvider')]
+    public function testWithInvalidBooleanValuesAndValidDefaultValue(mixed $value, bool $excepted): void
+    {
+        self::assertSame($excepted, $this->getValidator()->validate($value, ['default' => $excepted]));
+    }
+
+    public function testWithInvalidBooleanValuesAndInvalidDefaultValue(): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        $this->getValidator()->validate('n', ['default' => 'false']);
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  bool $excepted
-     * @return void
-     * @dataProvider invalidBooleanValuesWithOptionsProvider
      */
-    public function testWithInvalidBooleanWithDefaultValues($value, array $options, bool $excepted): void
+    #[DataProvider('invalidBooleanValuesWithOptionsProvider')]
+    public function testWithInvalidBooleanWithDefaultValues(mixed $value, array $options, bool $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  bool $excepted
-     * @return void
-     * @dataProvider invalidBooleanValuesWithOptionsProvider
      */
-    public function testWithInvalidBooleanWithDefaultForceNullValues($value, array $options, bool $excepted): void
+    #[DataProvider('invalidBooleanValuesWithOptionsProvider')]
+    public function testWithInvalidBooleanWithDefaultForceNullValues(mixed $value, array $options, bool $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options, FILTER_NULL_ON_FAILURE));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options, FILTER_NULL_ON_FAILURE));
     }
 
     /**
      * @return array<int, array<int, string|bool|int|null>>
      */
-    public function validTrueValuesProvider(): array
+    public static function validTrueValuesProvider(): array
     {
         return [
             ['yes', true],
@@ -109,7 +100,7 @@ class BooleanValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validFalseValuesProvider(): array
+    public static function validFalseValuesProvider(): array
     {
         return [
             ['no', false],
@@ -129,7 +120,7 @@ class BooleanValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function invalidBooleanValuesProvider(): array
+    public static function invalidBooleanValuesProvider(): array
     {
         return [
             ['non', false],
@@ -145,7 +136,7 @@ class BooleanValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function invalidBooleanValuesWithOptionsProvider(): array
+    public static function invalidBooleanValuesWithOptionsProvider(): array
     {
         return [
             ['non', ['default' => false], false],

--- a/tests/Unit/Validator/DateTimeValidatorTest.php
+++ b/tests/Unit/Validator/DateTimeValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\DateTimeValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -35,23 +36,23 @@ class DateTimeValidatorTest extends TestCase
      * @param  mixed $value
      * @param  mixed $excepted
      * @return void
-     * @dataProvider validValuesProvider
      */
-    public function testWithValidValues($value, $excepted): void
+    #[DataProvider('validValuesProvider')]
+    public function testWithValidValues(mixed $value, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
      * @param  mixed $value
      * @param  mixed $excepted
      * @return void
-     * @dataProvider invalidValuesProvider
      */
-    public function testWithInvalidValues($value, $excepted): void
+    #[DataProvider('invalidValuesProvider')]
+    public function testWithInvalidValues(mixed $value, mixed $excepted): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
@@ -59,11 +60,11 @@ class DateTimeValidatorTest extends TestCase
      * @param  array<string,string|null|int|float|bool> $options
      * @param  mixed $excepted
      * @return void
-     * @dataProvider validValuesWithOptionsProvider
      */
-    public function testWithValidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('validValuesWithOptionsProvider')]
+    public function testWithValidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
@@ -71,17 +72,17 @@ class DateTimeValidatorTest extends TestCase
      * @param  array<string,string|null|int|float|bool> $options
      * @param  mixed $excepted
      * @return void
-     * @dataProvider invalidValuesWithOptionsProvider
      */
-    public function testWithInvalidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('invalidValuesWithOptionsProvider')]
+    public function testWithInvalidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validValuesProvider(): array
+    public static function validValuesProvider(): array
     {
         return [
             ['2018-01-01 00:00:00', '2018-01-01 00:00:00'],
@@ -96,7 +97,7 @@ class DateTimeValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function invalidValuesProvider(): array
+    public static function invalidValuesProvider(): array
     {
         return [
             ['-2018-01-01 00:00:00', false],
@@ -108,7 +109,7 @@ class DateTimeValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string>>>
      */
-    public function validValuesWithOptionsProvider(): array
+    public static function validValuesWithOptionsProvider(): array
     {
         $default = '2001-01-01';
         $options = ['format' => 'Y-m-d H:i:s', 'format_output' => 'Y-m-d H:i:s', 'default' => $default];
@@ -118,16 +119,16 @@ class DateTimeValidatorTest extends TestCase
             ['2099-12-31 23:59:59', $options, '2099-12-31 23:59:59'],
             ['1901-07-01 12:00:00', $options, '1901-07-01 12:00:00'],
             ['2020-02-29 00:00:00', $options, '2020-02-29 00:00:00'],
-            ['12-31-2099 00:00:00', array_merge($options, ['format' => 'm-d-Y H:i:s', 'format_output' => 'd-m-Y H:i:s']), '31-12-2099 00:00:00'],
-            ['99-12-31 00:00:00',   array_merge($options, ['format' => 'y-m-d H:i:s']), '1999-12-31 00:00:00'],
-            ['01-07-1901 13:13',    array_merge($options, ['format' => 'd-m-Y H:i']), '1901-07-01 13:13:00'],
+            ['12-31-2099 00:00:00', \array_merge($options, ['format' => 'm-d-Y H:i:s', 'format_output' => 'd-m-Y H:i:s']), '31-12-2099 00:00:00'],
+            ['99-12-31 00:00:00',   \array_merge($options, ['format' => 'y-m-d H:i:s']), '1999-12-31 00:00:00'],
+            ['01-07-1901 13:13',    \array_merge($options, ['format' => 'd-m-Y H:i']), '1901-07-01 13:13:00'],
         ];
     }
 
     /**
      * @return array<array<string|bool|int|float|null|array<string,string>>>
      */
-    public function invalidValuesWithOptionsProvider(): array
+    public static function invalidValuesWithOptionsProvider(): array
     {
         $default = '2001-01-01 12:13:14';
         $options = ['format' => 'Y-m-d H:i:s', 'format_output' => 'Y-m-d H:i:s', 'default' => $default];

--- a/tests/Unit/Validator/DateValidatorTest.php
+++ b/tests/Unit/Validator/DateValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\DateValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,65 +24,46 @@ use PHPUnit\Framework\TestCase;
  */
 class DateValidatorTest extends TestCase
 {
-    /**
-     * @return ValidatorInterface
-     */
     public function getValidator(): ValidatorInterface
     {
         return new DateValidator();
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesProvider
-     */
-    public function testWithValidValues($value, $excepted): void
+    #[DataProvider('validValuesProvider')]
+    public function testWithValidValues(mixed $value, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesProvider
-     */
-    public function testWithInvalidValues($value, $excepted): void
+    #[DataProvider('invalidValuesProvider')]
+    public function testWithInvalidValues(mixed $value, mixed $excepted): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesWithOptionsProvider
      */
-    public function testWithValidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('validValuesWithOptionsProvider')]
+    public function testWithValidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesWithOptionsProvider
      */
-    public function testWithInvalidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('invalidValuesWithOptionsProvider')]
+    public function testWithInvalidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validValuesProvider(): array
+    public static function validValuesProvider(): array
     {
         return [
             ['2018-01-01', '2018-01-01'],
@@ -96,7 +78,7 @@ class DateValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function invalidValuesProvider(): array
+    public static function invalidValuesProvider(): array
     {
         return [
             ['-2018-01-01', false],
@@ -108,7 +90,7 @@ class DateValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string>>>
      */
-    public function validValuesWithOptionsProvider(): array
+    public static function validValuesWithOptionsProvider(): array
     {
         $default = '2001-01-01';
         $options = ['format' => 'Y-m-d', 'format_output' => 'Y-m-d', 'default' => $default];
@@ -118,16 +100,16 @@ class DateValidatorTest extends TestCase
             ['2099-12-31', $options, '2099-12-31'],
             ['1901-07-01', $options, '1901-07-01'],
             ['2020-02-29', $options, '2020-02-29'],
-            ['12-31-2099', array_merge($options, ['format' => 'm-d-Y', 'format_output' => 'd-m-Y']), '31-12-2099'],
-            ['99-12-31',   array_merge($options, ['format' => 'y-m-d']), '1999-12-31'],
-            ['01-07-1901', array_merge($options, ['format' => 'd-m-Y']), '1901-07-01'],
+            ['12-31-2099', \array_merge($options, ['format' => 'm-d-Y', 'format_output' => 'd-m-Y']), '31-12-2099'],
+            ['99-12-31',   \array_merge($options, ['format' => 'y-m-d']), '1999-12-31'],
+            ['01-07-1901', \array_merge($options, ['format' => 'd-m-Y']), '1901-07-01'],
         ];
     }
 
     /**
      * @return array<array<string|bool|int|float|null|array<string,string>>>
      */
-    public function invalidValuesWithOptionsProvider(): array
+    public static function invalidValuesWithOptionsProvider(): array
     {
         $default = '2001-01-01';
         $options = ['format' => 'Y-m-d', 'format_output' => 'Y-m-d', 'default' => $default];

--- a/tests/Unit/Validator/DomainValidatorTest.php
+++ b/tests/Unit/Validator/DomainValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\DomainValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,57 +32,41 @@ class DomainValidatorTest extends TestCase
         return new DomainValidator();
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesProvider
-     */
-    public function testWithValidValues($value, $excepted): void
+    #[DataProvider('validValuesProvider')]
+    public function testWithValidValues(mixed $value, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesProvider
-     */
-    public function testWithInvalidValues($value, $excepted): void
+    #[DataProvider('invalidValuesProvider')]
+    public function testWithInvalidValues(mixed $value, mixed $excepted): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesWithOptionsProvider
      */
-    public function testWithValidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('validValuesWithOptionsProvider')]
+    public function testWithValidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesWithOptionsProvider
      */
-    public function testWithInvalidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('invalidValuesWithOptionsProvider')]
+    public function testWithInvalidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validValuesProvider(): array
+    public static function validValuesProvider(): array
     {
         return [
             //~ Normal & complex cases
@@ -109,7 +94,7 @@ class DomainValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function invalidValuesProvider(): array
+    public static function invalidValuesProvider(): array
     {
         return [
             ['http://www.math..uio.no.example.net/faq/compression-faq/part1.html', false],
@@ -119,7 +104,7 @@ class DomainValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string>>>
      */
-    public function validValuesWithOptionsProvider(): array
+    public static function validValuesWithOptionsProvider(): array
     {
         return [
             //~ Normal & complex cases
@@ -145,7 +130,7 @@ class DomainValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<null>>>
      */
-    public function invalidValuesWithOptionsProvider(): array
+    public static function invalidValuesWithOptionsProvider(): array
     {
         return [
             ['http://www.math..uio.no.example.net/faq/compression-faq/part1.html', ['default' => null], null],

--- a/tests/Unit/Validator/EmailValidatorTest.php
+++ b/tests/Unit/Validator/EmailValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\EmailValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,57 +32,41 @@ class EmailValidatorTest extends TestCase
         return new EmailValidator();
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesProvider
-     */
-    public function testWithValidValues($value, $excepted): void
+    #[DataProvider('validValuesProvider')]
+    public function testWithValidValues(mixed $value, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesProvider
-     */
-    public function testWithInvalidValues($value, $excepted): void
+    #[DataProvider('invalidValuesProvider')]
+    public function testWithInvalidValues(mixed $value, mixed $excepted): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesWithOptionsProvider
      */
-    public function testWithValidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('validValuesWithOptionsProvider')]
+    public function testWithValidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesWithOptionsProvider
      */
-    public function testWithInvalidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('invalidValuesWithOptionsProvider')]
+    public function testWithInvalidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validValuesProvider(): array
+    public static function validValuesProvider(): array
     {
         return [
             ['test@localhost.com',           'test@localhost.com'],
@@ -97,7 +82,7 @@ class EmailValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function invalidValuesProvider(): array
+    public static function invalidValuesProvider(): array
     {
         return [
             ['Test Example <test@example.com>', false],
@@ -111,7 +96,7 @@ class EmailValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null>>>
      */
-    public function validValuesWithOptionsProvider(): array
+    public static function validValuesWithOptionsProvider(): array
     {
         $default = 'test@example.com';
         $options = ['default' => $default];
@@ -130,7 +115,7 @@ class EmailValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null>>>
      */
-    public function invalidValuesWithOptionsProvider(): array
+    public static function invalidValuesWithOptionsProvider(): array
     {
         $default = null;
         $options = ['default' => $default];

--- a/tests/Unit/Validator/FloatValidatorTest.php
+++ b/tests/Unit/Validator/FloatValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\FloatValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,51 +32,35 @@ class FloatValidatorTest extends TestCase
         return new FloatValidator();
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesProvider
-     */
-    public function testWithValidValues($value, $excepted): void
+    #[DataProvider('validValuesProvider')]
+    public function testWithValidValues(mixed $value, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesProvider
-     */
-    public function testWithInvalidValues($value, $excepted): void
+    #[DataProvider('invalidValuesProvider')]
+    public function testWithInvalidValues(mixed $value, mixed $excepted): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesWithOptionsProvider
      */
-    public function testWithValidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('validValuesWithOptionsProvider')]
+    public function testWithValidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesWithOptionsProvider
      */
-    public function testWithInvalidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('invalidValuesWithOptionsProvider')]
+    public function testWithInvalidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
@@ -83,13 +68,13 @@ class FloatValidatorTest extends TestCase
      */
     public function testWithValidValuesWithThousandSeparator(): void
     {
-        $this->assertSame(1000.01, $this->getValidator()->validate('1,000.01', [], FILTER_FLAG_ALLOW_THOUSAND));
+        self::assertSame(1000.01, $this->getValidator()->validate('1,000.01', [], FILTER_FLAG_ALLOW_THOUSAND));
     }
 
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validValuesProvider(): array
+    public static function validValuesProvider(): array
     {
         return [
             [0.0,  0.0],
@@ -103,7 +88,7 @@ class FloatValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function invalidValuesProvider(): array
+    public static function invalidValuesProvider(): array
     {
         return [
             ['0.0.0', false],
@@ -117,7 +102,7 @@ class FloatValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function validValuesWithOptionsProvider(): array
+    public static function validValuesWithOptionsProvider(): array
     {
         $default = -1.0;
         $options = ['default' => $default];
@@ -126,16 +111,16 @@ class FloatValidatorTest extends TestCase
             [0.0, $options, 0.0],
             [1.20, $options, 1.20],
             [0, $options, 0.0],
-            ['0,9999999999', array_merge($options, ['decimal' => ',']), 0.9999999999],
+            ['0,9999999999', \array_merge($options, ['decimal' => ',']), 0.9999999999],
             ['0.0', $options, 0.0],
-            ['0,9911111111', array_merge($options, ['decimal' => ',']), 0.9911111111],
+            ['0,9911111111', \array_merge($options, ['decimal' => ',']), 0.9911111111],
         ];
     }
 
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function invalidValuesWithOptionsProvider(): array
+    public static function invalidValuesWithOptionsProvider(): array
     {
         $default = 0.0;
         $options = ['default' => $default];

--- a/tests/Unit/Validator/IntegerValidatorTest.php
+++ b/tests/Unit/Validator/IntegerValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\IntegerValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,73 +32,51 @@ class IntegerValidatorTest extends TestCase
         return new IntegerValidator();
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesProvider
-     */
-    public function testWithValidValues($value, $excepted): void
+    #[DataProvider('validValuesProvider')]
+    public function testWithValidValues(mixed $value, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesProvider
-     */
-    public function testWithInvalidValues($value, $excepted): void
+    #[DataProvider('invalidValuesProvider')]
+    public function testWithInvalidValues(mixed $value, mixed $excepted): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesWithOptionsProvider
      */
-    public function testWithValidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('validValuesWithOptionsProvider')]
+    public function testWithValidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesWithOptionsProvider
      */
-    public function testWithInvalidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('invalidValuesWithOptionsProvider')]
+    public function testWithInvalidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
-    /**
-     * @return void
-     */
     public function testWithOctalValueAsValidValues(): void
     {
-        $this->assertSame(octdec('777'), $this->getValidator()->validate(0777, [], FILTER_FLAG_ALLOW_OCTAL));
+        self::assertSame(octdec('777'), $this->getValidator()->validate(0777, [], FILTER_FLAG_ALLOW_OCTAL));
     }
 
-    /**
-     * @return void
-     */
     public function testWithHexadecimalValueAsValidValues(): void
     {
-        $this->assertSame(hexdec('fa11'), $this->getValidator()->validate('0xfa11', [], FILTER_FLAG_ALLOW_HEX));
+        self::assertSame(hexdec('fa11'), $this->getValidator()->validate('0xfa11', [], FILTER_FLAG_ALLOW_HEX));
     }
 
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validValuesProvider(): array
+    public static function validValuesProvider(): array
     {
         return [
             [0.0,  0],
@@ -110,7 +89,7 @@ class IntegerValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function invalidValuesProvider(): array
+    public static function invalidValuesProvider(): array
     {
         return [
             [1.20, 1],
@@ -128,7 +107,7 @@ class IntegerValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function validValuesWithOptionsProvider(): array
+    public static function validValuesWithOptionsProvider(): array
     {
         $default = -1;
         $options = ['default' => $default];
@@ -137,16 +116,16 @@ class IntegerValidatorTest extends TestCase
             [0.0, ['default' => $default], 0],
             [15, ['default' => $default, 'min_range' => 0, 'max_range' => 100], 15],
             ['42', ['default' => $default, 'min_range' => 42, 'max_range' => 42], 42],
-            [-128,  array_merge($options, IntegerValidator::TINYINT_SIGNED), -128],
-            [127,  array_merge($options, IntegerValidator::TINYINT_SIGNED), 127],
-            [128,  array_merge($options, IntegerValidator::TINYINT_UNSIGNED), 128],
+            [-128, \array_merge($options, IntegerValidator::TINYINT_SIGNED), -128],
+            [127,  \array_merge($options, IntegerValidator::TINYINT_SIGNED), 127],
+            [128,  \array_merge($options, IntegerValidator::TINYINT_UNSIGNED), 128],
         ];
     }
 
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function invalidValuesWithOptionsProvider(): array
+    public static function invalidValuesWithOptionsProvider(): array
     {
         $default = -1;
         $options = ['default' => $default];
@@ -156,9 +135,9 @@ class IntegerValidatorTest extends TestCase
             [null, $options, $default],
             [1.20, ['default' => $default], $default],
             [1.20, ['default' => $default, 'min_range' => 1, 'max_range' => 2], $default],
-            [1.01, array_merge($options, ['min_range' => 0, 'max_range' => 1]), $default],
-            [254,  array_merge($options, IntegerValidator::TINYINT_SIGNED), $default],
-            [256,  array_merge($options, IntegerValidator::TINYINT_UNSIGNED), $default],
+            [1.01, \array_merge($options, ['min_range' => 0, 'max_range' => 1]), $default],
+            [254,  \array_merge($options, IntegerValidator::TINYINT_SIGNED), $default],
+            [256,  \array_merge($options, IntegerValidator::TINYINT_UNSIGNED), $default],
         ];
     }
 }

--- a/tests/Unit/Validator/IpValidatorTest.php
+++ b/tests/Unit/Validator/IpValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\IpValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,101 +32,70 @@ class IpValidatorTest extends TestCase
         return new IpValidator();
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesProvider
-     */
-    public function testWithValidValues($value, $excepted): void
+    #[DataProvider('validValuesProvider')]
+    public function testWithValidValues(mixed $value, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesProvider
-     */
-    public function testWithInvalidValues($value, $excepted): void
+    #[DataProvider('invalidValuesProvider')]
+    public function testWithInvalidValues(mixed $value, mixed $excepted): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesWithOptionsProvider
      */
-    public function testWithValidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('validValuesWithOptionsProvider')]
+    public function testWithValidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesWithOptionsProvider
      */
-    public function testWithInvalidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('invalidValuesWithOptionsProvider')]
+    public function testWithInvalidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
-    /**
-     * @return void
-     */
     public function testIpNotInReservedNorPrivateRangesWithPublicIp(): void
     {
-        $this->assertSame('193.1.2.3', $this->getValidator()->validate('193.1.2.3', [], FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_PRIV_RANGE));
+        self::assertSame('193.1.2.3', $this->getValidator()->validate('193.1.2.3', [], FILTER_FLAG_NO_RES_RANGE | FILTER_FLAG_NO_PRIV_RANGE));
     }
 
-    /**
-     * @return void
-     */
     public function testIpNotInReservedRangeWithReservedIp(): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame('240.0.0.1', $this->getValidator()->validate('240.0.0.1', [], FILTER_FLAG_NO_RES_RANGE));
+        self::assertSame('240.0.0.1', $this->getValidator()->validate('240.0.0.1', [], FILTER_FLAG_NO_RES_RANGE));
     }
 
-    /**
-     * @return void
-     */
     public function testIpNotInPrivateRangeWithPrivateIp(): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame('172.16.0.1', $this->getValidator()->validate('172.16.0.1', [], FILTER_FLAG_NO_PRIV_RANGE));
+        self::assertSame('172.16.0.1', $this->getValidator()->validate('172.16.0.1', [], FILTER_FLAG_NO_PRIV_RANGE));
     }
 
-    /**
-     * @return void
-     */
     public function testIpV6WithValidValue(): void
     {
-        $this->assertSame('2001:0db8:0000:85a3:0000:0000:ac1f:8001', $this->getValidator()->validate('2001:0db8:0000:85a3:0000:0000:ac1f:8001', [], FILTER_FLAG_IPV6));
-        $this->assertSame('2001:db8:0:85a3:0:0:ac1f:8001', $this->getValidator()->validate('2001:db8:0:85a3:0:0:ac1f:8001', [], FILTER_FLAG_IPV6));
+        self::assertSame('2001:0db8:0000:85a3:0000:0000:ac1f:8001', $this->getValidator()->validate('2001:0db8:0000:85a3:0000:0000:ac1f:8001', [], FILTER_FLAG_IPV6));
+        self::assertSame('2001:db8:0:85a3:0:0:ac1f:8001', $this->getValidator()->validate('2001:db8:0:85a3:0:0:ac1f:8001', [], FILTER_FLAG_IPV6));
     }
 
-    /**
-     * @return void
-     */
     public function testIpV6WithInvalidValue(): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame('test:0db8:0000:85a3:0000:0000:ac1f:8001', $this->getValidator()->validate('test:0db8:0000:85a3:0000:0000:ac1f:8001', [], FILTER_FLAG_IPV4));
+        self::assertSame('test:0db8:0000:85a3:0000:0000:ac1f:8001', $this->getValidator()->validate('test:0db8:0000:85a3:0000:0000:ac1f:8001', [], FILTER_FLAG_IPV4));
     }
 
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validValuesProvider(): array
+    public static function validValuesProvider(): array
     {
         return [
             ['192.168.0.1',     '192.168.0.1'],
@@ -137,7 +107,7 @@ class IpValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function invalidValuesProvider(): array
+    public static function invalidValuesProvider(): array
     {
         return [
             ['192.168.0.256',   false],
@@ -148,7 +118,7 @@ class IpValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function validValuesWithOptionsProvider(): array
+    public static function validValuesWithOptionsProvider(): array
     {
         return [
             ['192.168.0.1',     ['default' => null], '192.168.0.1'],
@@ -160,7 +130,7 @@ class IpValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function invalidValuesWithOptionsProvider(): array
+    public static function invalidValuesWithOptionsProvider(): array
     {
         return [
             ['192.168.0.256', ['default' => null], null],

--- a/tests/Unit/Validator/NullValidatorTest.php
+++ b/tests/Unit/Validator/NullValidatorTest.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\NullValidator;
@@ -36,7 +36,7 @@ class NullValidatorTest extends TestCase
      */
     public function testWithNullValue(): void
     {
-        $this->assertSame(null, $this->getValidator()->validate(null));
+        self::assertNull($this->getValidator()->validate(null));
     }
 
     /**
@@ -45,6 +45,6 @@ class NullValidatorTest extends TestCase
     public function testWithEmptyStringValue(): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame(null, $this->getValidator()->validate(''));
+        self::assertNull($this->getValidator()->validate(''));
     }
 }

--- a/tests/Unit/Validator/RegexpValidatorTest.php
+++ b/tests/Unit/Validator/RegexpValidatorTest.php
@@ -9,7 +9,7 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\RegexpValidator;
@@ -37,7 +37,7 @@ class RegexpValidatorTest extends TestCase
     public function testWithValidValue(): void
     {
         $text = 'The test passed!';
-        $this->assertSame($text, $this->getValidator()->validate($text, ['regexp' => '`(.*)passed!`']));
+        self::assertSame($text, $this->getValidator()->validate($text, ['regexp' => '`(.*)passed!`']));
     }
 
     /**
@@ -47,6 +47,6 @@ class RegexpValidatorTest extends TestCase
     {
         $text = 'The test failed!';
         $this->expectException(ValidationException::class);
-        $this->assertSame($text, $this->getValidator()->validate($text, ['regexp' => '`(.+)passed(.*)`']));
+        self::assertSame($text, $this->getValidator()->validate($text, ['regexp' => '`(.+)passed(.*)`']));
     }
 }

--- a/tests/Unit/Validator/StringValidatorTest.php
+++ b/tests/Unit/Validator/StringValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\StringValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,71 +32,58 @@ class StringValidatorTest extends TestCase
         return new StringValidator();
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesProvider
-     */
-    public function testWithValidValues($value, $excepted): void
+    #[DataProvider('validValuesProvider')]
+    public function testWithValidValues(mixed $value, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @return void
-     * @dataProvider invalidValuesProvider
      */
-    public function testWithInvalidValues($value, array $options): void
+    #[DataProvider('invalidValuesProvider')]
+    public function testWithInvalidValues(mixed $value, array $options): void
     {
         $this->expectException(ValidationException::class);
         $this->getValidator()->validate($value, $options);
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesWithOptionsProvider
      */
-    public function testWithValidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('validValuesWithOptionsProvider')]
+    public function testWithValidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesWithOptionsProvider
      */
-    public function testWithInvalidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('invalidValuesWithOptionsProvider')]
+    public function testWithInvalidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validValuesProvider(): array
+    public static function validValuesProvider(): array
     {
         return [
             ['',  ''],
             ['string', 'string'],
             ['This is a valid string', 'This is a valid string'],
             [' ! €$#!@ :)', ' ! €$#!@ :)'],
-            ['42', '42']
+            ['42', '42'],
         ];
     }
 
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function invalidValuesProvider(): array
+    public static function invalidValuesProvider(): array
     {
         return [
             [42, []],
@@ -103,13 +91,16 @@ class StringValidatorTest extends TestCase
             [false, []],
             ['a', ['min_length' => 2]],
             ['abcdefghijklmnopqrstuvwxyz', ['min_length' => 1, 'max_length' => 25]],
+            ['', ['default' => '', 'min_length' => 1]],
+            ['abcdefghijklmnopqrstuvwxyz', ['default' => '', 'min_length' => 1, 'max_length' => 25]],
+            ['abcdefghijklmnopqrstuvwxyz', ['default' => '', 'min_length' => 1, 'max_length' => 25]],
         ];
     }
 
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function validValuesWithOptionsProvider(): array
+    public static function validValuesWithOptionsProvider(): array
     {
         $options = ['default' => ''];
         return [
@@ -117,14 +108,14 @@ class StringValidatorTest extends TestCase
             ['string', $options, 'string'],
             ['This is a valid string', $options, 'This is a valid string'],
             [' ! €$#!@ :)', $options, ' ! €$#!@ :)'],
-            ['42', $options, '42']
+            ['42', $options, '42'],
         ];
     }
 
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function invalidValuesWithOptionsProvider(): array
+    public static function invalidValuesWithOptionsProvider(): array
     {
         $default = '';
         $options = ['default' => $default];
@@ -133,9 +124,6 @@ class StringValidatorTest extends TestCase
             [42, $options, $default],
             [null, $options, $default],
             [false, $options, $default],
-            ['', array_merge($options, ['min_length' => 1]), $default],
-            ['abcdefghijklmnopqrstuvwxyz', array_merge($options, ['max_length' => 25]), $default],
-            ['abcdefghijklmnopqrstuvwxyz', array_merge($options, ['min_length' => 1, 'max_length' => 25]), $default],
         ];
     }
 }

--- a/tests/Unit/Validator/TimeValidatorTest.php
+++ b/tests/Unit/Validator/TimeValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\TimeValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,57 +32,41 @@ class TimeValidatorTest extends TestCase
         return new TimeValidator();
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesProvider
-     */
-    public function testWithValidValues($value, $excepted): void
+    #[DataProvider('validValuesProvider')]
+    public function testWithValidValues(mixed $value, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesProvider
-     */
-    public function testWithInvalidValues($value, $excepted): void
+    #[DataProvider('invalidValuesProvider')]
+    public function testWithInvalidValues(mixed $value, mixed $excepted): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesWithOptionsProvider
      */
-    public function testWithValidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('validValuesWithOptionsProvider')]
+    public function testWithValidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesWithOptionsProvider
      */
-    public function testWithInvalidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('invalidValuesWithOptionsProvider')]
+    public function testWithInvalidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validValuesProvider(): array
+    public static function validValuesProvider(): array
     {
         return [
             ['00:00:00', '00:00:00'],
@@ -94,7 +79,7 @@ class TimeValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function invalidValuesProvider(): array
+    public static function invalidValuesProvider(): array
     {
         return [
             ['-00:00:00', false],
@@ -106,7 +91,7 @@ class TimeValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string>>>
      */
-    public function validValuesWithOptionsProvider(): array
+    public static function validValuesWithOptionsProvider(): array
     {
         $default = '00:00:00';
         $options = ['format' => 'H:i:s', 'format_output' => 'H:i:s', 'default' => $default];
@@ -116,8 +101,8 @@ class TimeValidatorTest extends TestCase
             ['23:59:59', $options, '23:59:59'],
             ['12:00:00', $options, '12:00:00'],
             ['24:00:00', $options, '00:00:00'],
-            ['23:59:59', array_merge($options, ['format_output' => 'H:i']), '23:59'],
-            ['23:59',    array_merge($options, ['format' => 'H:i']), '23:59:00'],
+            ['23:59:59', \array_merge($options, ['format_output' => 'H:i']), '23:59'],
+            ['23:59',    \array_merge($options, ['format' => 'H:i']), '23:59:00'],
             ['1:00', $options, '00:00:00'],
         ];
     }
@@ -125,15 +110,15 @@ class TimeValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string>>>
      */
-    public function invalidValuesWithOptionsProvider(): array
+    public static function invalidValuesWithOptionsProvider(): array
     {
         $default = '00:00:00';
         $options = ['format' => 'H:i:s', 'format_output' => 'H:i:s', 'default' => $default];
 
         return [
-            ['-10:00:00', array_merge($options, ['format' => '-H:i:s']), '10:00:00'],
-            ['10:00',     array_merge($options, ['format' => 'H:i']), '10:00:00'],
-            ['1:00',      array_merge($options, ['format' => 'h:i']), '01:00:00'],
+            ['-10:00:00', \array_merge($options, ['format' => '-H:i:s']), '10:00:00'],
+            ['10:00',     \array_merge($options, ['format' => 'H:i']), '10:00:00'],
+            ['1:00',      \array_merge($options, ['format' => 'h:i']), '01:00:00'],
         ];
     }
 }

--- a/tests/Unit/Validator/TimestampValidatorTest.php
+++ b/tests/Unit/Validator/TimestampValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\TimestampValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,73 +32,51 @@ class TimestampValidatorTest extends TestCase
         return new TimestampValidator();
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesProvider
-     */
-    public function testWithValidValues($value, $excepted): void
+    #[DataProvider('validValuesProvider')]
+    public function testWithValidValues(mixed $value, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesProvider
-     */
-    public function testWithInvalidValues($value, $excepted): void
+    #[DataProvider('invalidValuesProvider')]
+    public function testWithInvalidValues(mixed $value, mixed $excepted): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesWithOptionsProvider
      */
-    public function testWithValidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('validValuesWithOptionsProvider')]
+    public function testWithValidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
     /**
-     * @param  mixed $value
      * @param  array<string,string|null|int|float|bool> $options
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesWithOptionsProvider
      */
-    public function testWithInvalidValueAndDefaultValues($value, array $options, $excepted): void
+    #[DataProvider('invalidValuesWithOptionsProvider')]
+    public function testWithInvalidValueAndDefaultValues(mixed $value, array $options, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value, $options));
+        self::assertSame($excepted, $this->getValidator()->validate($value, $options));
     }
 
-    /**
-     * @return void
-     */
     public function testWithOctalValueAsValidValues(): void
     {
-        $this->assertSame(octdec('777'), $this->getValidator()->validate(0777, [], FILTER_FLAG_ALLOW_OCTAL));
+        self::assertSame(octdec('777'), $this->getValidator()->validate(0777, [], FILTER_FLAG_ALLOW_OCTAL));
     }
 
-    /**
-     * @return void
-     */
     public function testWithHexadecimalValueAsValidValues(): void
     {
-        $this->assertSame(hexdec('fa11'), $this->getValidator()->validate('0xfa11', [], FILTER_FLAG_ALLOW_HEX));
+        self::assertSame(hexdec('fa11'), $this->getValidator()->validate('0xfa11', [], FILTER_FLAG_ALLOW_HEX));
     }
 
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validValuesProvider(): array
+    public static function validValuesProvider(): array
     {
         return [
             [0.0,  0],
@@ -110,7 +89,7 @@ class TimestampValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function invalidValuesProvider(): array
+    public static function invalidValuesProvider(): array
     {
         return [
             [-1,  false],
@@ -122,7 +101,7 @@ class TimestampValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function validValuesWithOptionsProvider(): array
+    public static function validValuesWithOptionsProvider(): array
     {
         $default = -1;
         $options = ['default' => $default];
@@ -137,7 +116,7 @@ class TimestampValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null|array<string,string|null|int|float|bool>>>
      */
-    public function invalidValuesWithOptionsProvider(): array
+    public static function invalidValuesWithOptionsProvider(): array
     {
         $default = 0;
         $options = ['default' => $default];

--- a/tests/Unit/Validator/UrlValidatorTest.php
+++ b/tests/Unit/Validator/UrlValidatorTest.php
@@ -9,11 +9,12 @@
 
 declare(strict_types=1);
 
-namespace Eureka\Component\Validation\Tests\Validator;
+namespace Eureka\Component\Validation\Tests\Unit\Validator;
 
 use Eureka\Component\Validation\Exception\ValidationException;
 use Eureka\Component\Validation\Validator\UrlValidator;
 use Eureka\Component\Validation\ValidatorInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,33 +32,23 @@ class UrlValidatorTest extends TestCase
         return new UrlValidator();
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider validValuesProvider
-     */
-    public function testWithValidValues($value, $excepted): void
+    #[DataProvider('validValuesProvider')]
+    public function testWithValidValues(mixed $value, mixed $excepted): void
     {
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
-    /**
-     * @param  mixed $value
-     * @param  mixed $excepted
-     * @return void
-     * @dataProvider invalidValuesProvider
-     */
-    public function testWithInvalidValues($value, $excepted): void
+    #[DataProvider('invalidValuesProvider')]
+    public function testWithInvalidValues(mixed $value, mixed $excepted): void
     {
         $this->expectException(ValidationException::class);
-        $this->assertSame($excepted, $this->getValidator()->validate($value));
+        self::assertSame($excepted, $this->getValidator()->validate($value));
     }
 
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function validValuesProvider(): array
+    public static function validValuesProvider(): array
     {
         return [
             ['http://www.math.uio.no.example.net/faq/compression-faq/part1.html', 'http://www.math.uio.no.example.net/faq/compression-faq/part1.html'],
@@ -78,7 +69,7 @@ class UrlValidatorTest extends TestCase
     /**
      * @return array<array<string|bool|int|float|null>>
      */
-    public function invalidValuesProvider(): array
+    public static function invalidValuesProvider(): array
     {
         return [
 


### PR DESCRIPTION
- Support for PHP 8.4
- Drop support for PHP 7.4, 8.0, 8.1, and 8.2
- String validator now throws an exception if values has not the required length, rather than returning default value.
- Boolean validator now return `null` if the value is not a boolean, rather than return `false`.
- Type as enforced on validator to return appropriate type (or null if applicable)
- CI improvements